### PR TITLE
fix: typo in nodejs function description

### DIFF
--- a/fun-create-repo.md
+++ b/fun-create-repo.md
@@ -129,7 +129,7 @@ You can create Functions in many different programming languages. When your Func
 ### Including modules for a Node.js Function
 {: #function-nodejs-dep-repo}
 
-Create a function that includes a dependency for a specific Python module by creating a `package.json` file. In this case, both the source code and package file are located in the same folder.
+Create a function that includes a dependency for a specific Node.js module by creating a `package.json` file. In this case, both the source code and package file are located in the same folder.
 
 1. Create your source code by writing your code into a `main.js` file. For example, copy the following code example into a file called `main.js`.
 


### PR DESCRIPTION
What: the nodejs docs talk about python dependencies. This pr fixes the wording